### PR TITLE
Add support for auto fill hints

### DIFF
--- a/lib/src/flutter_pin_code_fields.dart
+++ b/lib/src/flutter_pin_code_fields.dart
@@ -59,6 +59,9 @@ class PinCodeFields extends StatefulWidget {
   /// Default is false
   final bool autofocus;
 
+  /// A list of strings that helps the autofill service identify the type of this text input.
+  final Iterable<String>? autofillHints;
+
   /// Custom text style
   final TextStyle textStyle;
 
@@ -147,6 +150,7 @@ class PinCodeFields extends StatefulWidget {
     this.focusNode,
     this.onChange,
     required this.onComplete,
+    this.autofillHints,
   });
 
   @override

--- a/lib/src/pin_code_fields_state.dart
+++ b/lib/src/pin_code_fields_state.dart
@@ -40,6 +40,7 @@ class PinCodeFieldsState extends State<PinCodeFields> {
                 controller: _textEditingController,
                 focusNode: _focusNode,
                 enabled: widget.enabled,
+                autofillHints: widget.autofillHints,
                 autofocus: widget.autofocus,
                 autocorrect: false,
                 keyboardType: widget.keyboardType,


### PR DESCRIPTION
# Pull request template

## What's changed?

Added support for autofill hints. Now you can pass autofillHints (e.g. AutofillHints.oneTimeCode) to TextFormField.
It allow you to paste One Time Code from SMS to PinCodeFields (Tested on Pixel 4 emulator) 

## How does this work?

It just passing argument autofillHints to TextFromField.autofillHints from top-level widget.

### Release Notes

Add support for auto fill hints